### PR TITLE
fix: improve firebase google login reliability

### DIFF
--- a/client/src/components/FirebaseAuth.tsx
+++ b/client/src/components/FirebaseAuth.tsx
@@ -112,40 +112,24 @@ const FirebaseAuth: React.FC<FirebaseAuthProps> = ({
 
   // Google Auth - Redirect Mode
   const handleGoogleAuth = async () => {
-    console.log('🚀 FirebaseAuth: handleGoogleAuth called!');
-    console.log('🔍 FirebaseAuth: Loading state:', loading);
-    
-    if (loading) {
-      console.log('🚫 FirebaseAuth: Already loading, returning...');
-      return;
-    }
-    
+    if (loading) return;
+
     setLoading(true);
     setError('');
-    setSuccess('Google\'a yönlendiriliyor...');
-    console.log('✅ FirebaseAuth: State updated, calling loginWithGoogle...');
+    setSuccess('');
 
     try {
-      console.log('📡 FirebaseAuth: Calling loginWithGoogle function...');
       const result = await loginWithGoogle();
-      console.log('📊 FirebaseAuth: loginWithGoogle result:', result);
-      
-      if (!result.success) {
-        console.log('❌ FirebaseAuth: Google login failed:', result.error);
-        if (result.error !== 'Giriş işlemi iptal edildi') {
-          setError(result.error || 'Google ile giriş başarısız');
-          setSuccess('');
-        }
+
+      if (result.success) {
+        setSuccess(result.message || 'Google ile giriş başarılı!');
       } else {
-        console.log('✅ FirebaseAuth: Google login successful!');
-        setSuccess('Google\'a yönlendiriliyor...');
+        setError(result.error || 'Google ile giriş başarısız');
       }
     } catch (error: any) {
-      console.error('💥 FirebaseAuth: Google auth exception:', error);
       setError(error.message || 'Google ile giriş başarısız');
-      setSuccess('');
     } finally {
-      console.log('🏁 FirebaseAuth: handleGoogleAuth completed');
+      setLoading(false);
     }
   };
 

--- a/client/src/firebase/auth.ts
+++ b/client/src/firebase/auth.ts
@@ -3,6 +3,7 @@ import {
   createUserWithEmailAndPassword,
   signInWithRedirect,
   getRedirectResult,
+  signInWithPopup,
   GoogleAuthProvider,
   signOut as firebaseSignOut,
   updateProfile,
@@ -80,20 +81,28 @@ export const loginWithGoogle = async () => {
     return { success: false, error: 'Giriş işlemi devam ediyor' };
   }
 
+  googleLoginInProgress = true;
+
+  console.log('🚀 Auth: Google login started (redirect mode)');
   try {
-    console.log('🚀 Auth: Google login started (redirect mode)');
-    googleLoginInProgress = true;
-    
-    // Redirect kullan - popup yerine
+    // İlk olarak redirect dene
     await signInWithRedirect(auth, googleProvider);
-    
-    // Redirect başlatıldı
     console.log('🔄 Auth: Redirecting to Google...');
     return { success: true, message: 'Google\'a yönlendiriliyor...' };
-  } catch (error: any) {
-    console.error('❌ Auth: Google redirect failed:', error);
-    googleLoginInProgress = false;
-    return { success: false, error: error.message };
+  } catch (redirectError: any) {
+    console.warn('⚠️ Auth: Redirect failed, trying popup instead', redirectError);
+
+    try {
+      // Redirect başarısız olursa popup'a düş
+      const popupResult = await signInWithPopup(auth, googleProvider);
+      console.log('✅ Auth: Popup login successful');
+      return { success: true, user: popupResult.user };
+    } catch (error: any) {
+      console.error('❌ Auth: Google login failed:', error);
+      return { success: false, error: error.message };
+    } finally {
+      googleLoginInProgress = false;
+    }
   }
 };
 


### PR DESCRIPTION
## Summary
- fall back to popup sign-in when Google redirect sign-in fails
- reset auth modal state after Google sign-in attempts

## Testing
- `npm run lint` *(fails: 51 problems (50 errors, 1 warning))*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689b536a37548330ae9e7b83079a45b7