### PR TITLE
refactor: replace wildcard catch-all route handler

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -29,7 +29,7 @@ app.get('/api/health', (req, res) => {
 });
 
 // Catch-all handler: client-side routing için
-app.get('*', (req, res) => {
+app.use((req, res) => {
   res.sendFile(path.join(clientPath, 'index.html'));
 });
 


### PR DESCRIPTION
## Summary
- use `app.use` instead of `app.get('*')` for client-side routing catch-all in Express 5

## Testing
- `npm test` (fails: Error: no test specified)
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68b7e418694c8330be239194d98a9622